### PR TITLE
refactor(api-connector): js example

### DIFF
--- a/encryption_example/Encryption.js
+++ b/encryption_example/Encryption.js
@@ -1,4 +1,5 @@
-const crypto = require('crypto');
+const qs = require('qs')
+const cryptojs = require('crypto-js')
 
 var apiKey = "";
 var secret = "";
@@ -12,13 +13,8 @@ var params = {
 
 console.log(getSignature(params, secret));
 
-function getSignature(parameters, secret) {
-	var orderedParams = "";
-	Object.keys(parameters).sort().forEach(function(key) {
-	  orderedParams += key + "=" + parameters[key] + "&";
-	});
-	orderedParams = orderedParams.substring(0, orderedParams.length - 1);
-
-	return crypto.createHmac('sha256', secret).update(orderedParams).digest('hex');
+function getSignature(params, secret) {
+  const payload = qs.stringify(params, { sort: (a, b) => a.localeCompare(b) })
+  return cryptojs.HmacSHA256(payload, secret).toString(cryptojs.enc.Hex)
 }
 


### PR DESCRIPTION
1. [crypto](https://www.npmjs.com/package/crypto) is deprecated. [crypto-js](https://www.npmjs.com/package/crypto-js) is used instead.

2. An algorithm of creating a querystring from json is delegated to a dedicated library: [qs](https://www.npmjs.com/package/qs) 

Thanks.